### PR TITLE
Add terraform example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+terraform/.terraform.lock.hcl
+terraform/.terraform/
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,45 @@
+# Terraform example
+
+This example deploys a single-container service
+([`basic-service.yaml`](basic-service.yaml)) and uses Terraform to apply the
+multi-container sidecar Collector to it.
+
+## Running the example
+
+First, follow the steps from the [main README](../README.md#getting-started) to:
+
+1. [Build the sample app](../README.md#build-the-sample-app)
+2. [Build the Collector image](../README.md#build-the-collector-image)
+
+Next, replace the `%GCP_PROJECT%` placeholder in
+[`basic-service.yaml`](basic-service.yaml) and [`main.tf`](main.tf) with your
+GCP project ID:
+
+```
+export GCP_PROJECT=<your project>
+sed -i s@%GCP_PROJECT%@${GCP_PROJECT}@g basic-service.yaml
+sed -i s@%GCP_PROJECT%@${GCP_PROJECT}@g main.tf
+```
+
+Deploy the basic Service:
+
+```
+gcloud run services replace basic-service.yaml
+```
+
+Save the Service URL from this command.
+
+You should now be able to see the Service is deployed, but there is no telemetry
+data exported to GCP.
+
+Modify the service using Terraform with the following commands:
+
+```
+terraform init
+terraform apply
+```
+
+When prompted by `terraform apply`, enter `yes` to confirm the changes.
+
+Use `curl` to hit the Service endpoint a few times and you will start to see
+telemetry data flowing in (just like in the [main README guide](../README.md#view-telemetry-in-google-cloud)).

--- a/terraform/basic-service.yaml
+++ b/terraform/basic-service.yaml
@@ -1,0 +1,42 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: opentelemetry-cloud-run-terraform
+  labels:
+    cloud.googleapis.com/location: "us-east1"
+  annotations:
+    run.googleapis.com/launch-stage: ALPHA
+spec:
+  template:
+    metadata:
+      annotations:
+        run.googleapis.com/execution-environment: gen1
+    spec:
+      containers:
+      - image: "us-east1-docker.pkg.dev/%GCP_PROJECT%/run-otel-example/sample-app"
+        name: app
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - mountPath: /logging
+          name: shared-logs
+      volumes:
+      - name: shared-logs
+        emptyDir:
+          medium: Memory
+          sizeLimit: 512Mi
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,50 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+provider "google" {
+  project = "%GCP_PROJECT%"
+}
+
+resource "google_cloud_run_v2_service" "default" {
+  name     = "opentelemetry-cloud-run-terraform"
+  location = "us-central1"
+  launch_stage = "ALPHA"
+
+  template {
+    annotations = {
+      "run.googleapis.com/client-name" = "terraform"
+      "run.googleapis.com/container-dependencies" = "{'app':['collector']}"
+    }
+    containers {
+      name = "app"
+      image = "us-east1-docker.pkg.dev/%GCP_PROJECT%/run-otel-example/sample-app"
+      ports {
+        container_port = "8080"
+      }
+    }
+    containers {
+      name = "collector"
+      image = "us-east1-docker.pkg.dev/%GCP_PROJECT%/run-otel-example/collector"
+      startup_probe {
+        http_get {
+          port = "13133"
+        }
+      }
+      volume_mounts {
+        name = "shared-logs"
+        mount_path = "/logging"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds an example for injecting the sidecar with Terraform.

(note this does not currently work with startup ordering until the changes in https://github.com/hashicorp/terraform-provider-google/pull/14358 are published in a release)