### PR TITLE
Set healthcheck endpoint to 0.0.0.0 for newer collector versions

### DIFF
--- a/configs/log-file.yaml
+++ b/configs/log-file.yaml
@@ -21,7 +21,7 @@ receivers:
       grpc:
       http:
   filelog:
-    include: [ /logging/*.log ]
+    include: [/logging/*.log]
     start_at: beginning
 
 processors:
@@ -32,6 +32,7 @@ processors:
 
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
 
 exporters:
   googlecloud:

--- a/configs/push-metrics.yaml
+++ b/configs/push-metrics.yaml
@@ -35,6 +35,7 @@ exporters:
 
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
 
 service:
   extensions: [health_check]

--- a/configs/rename-metric-attributes.yaml
+++ b/configs/rename-metric-attributes.yaml
@@ -54,6 +54,7 @@ exporters:
 
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
 
 service:
   extensions: [health_check]

--- a/configs/traces.yaml
+++ b/configs/traces.yaml
@@ -33,6 +33,7 @@ exporters:
 
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
 
 service:
   extensions: [health_check]


### PR DESCRIPTION
I noticed that recent collector versions have switched the feature gate to default endpoints such as health check to be `localhost`. Since health check is accessed by control plane, it needs to be accessible from outside. I found this when deploying without setting the endpoint with the latest collector, cloud run health check always failing for it, and succeeding after setting the endpoint.

Setting the endpoint will have no harm on older versions so this allows the configs to be compatible with newer and older binaries.