### PR TITLE
remove unrecognized flag from create SA script

### DIFF
--- a/create-service-account.sh
+++ b/create-service-account.sh
@@ -23,7 +23,6 @@ REGION="us-east1"
 gcloud iam service-accounts create "${SA_NAME}" \
   --description="A service account just to used for Cloud Run observability demo. https://github.com/GoogleCloudPlatform/opentelemetry-cloud-run" \
   --display-name="Cloud Run OpenTelemetry demo service account" \
-  --condition=None \
   --quiet
 
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \


### PR DESCRIPTION
### Description

When following instructions from the README to build the cloud run service via cloud build,  the following error was seen: 

1. The flag `condition` was not recognized. I did not find it on the [reference page](https://cloud.google.com/sdk/gcloud/reference/iam/service-accounts/create) either.
```text
++ gcloud config get-value project
+ PROJECT_ID=otel-test
+ SA_NAME=run-otel-example-sa
+ REGION=us-east1
+ gcloud iam service-accounts create run-otel-example-sa '--description=A service account just to used for Cloud Run observability demo. https://github.com/GoogleCloudPlatform/opentelemetry-cloud-run' '--display-name=Cloud Run OpenTelemetry demo service account' --condition=None --quiet
ERROR: (gcloud.iam.service-accounts.create) unrecognized arguments: --condition=None (did you mean '--configuration'?) 

To search the help text of gcloud commands, run:
  gcloud help -- SEARCH_TERMS
```
Removing the flag, resulted in a successful execution of the script.
