### PR TITLE
Listen on `0.0.0.0` in collector

### DIFF
--- a/collector/collector-config.yaml
+++ b/collector/collector-config.yaml
@@ -16,7 +16,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        0.0.0.0:4317
       http:
+        0.0.0.0:4318
 
   filelog:
     include: [ /logging/*.log ]

--- a/configs/log-file.yaml
+++ b/configs/log-file.yaml
@@ -19,7 +19,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        0.0.0.0:4317
       http:
+        0.0.0.0:4318
   filelog:
     include: [/logging/*.log]
     start_at: beginning

--- a/configs/push-metrics.yaml
+++ b/configs/push-metrics.yaml
@@ -21,7 +21,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        0.0.0.0:4317
       http:
+        0.0.0.0:4318
 
 processors:
   # automatically detect Cloud Run resource metadata

--- a/configs/rename-metric-attributes.yaml
+++ b/configs/rename-metric-attributes.yaml
@@ -21,7 +21,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        0.0.0.0:4317
       http:
+        0.0.0.0:4318
 
 processors:
   # automatically detect Cloud Run resource metadata

--- a/configs/traces.yaml
+++ b/configs/traces.yaml
@@ -20,7 +20,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        0.0.0.0:4317
       http:
+        0.0.0.0:4318
 
 processors:
   resourcedetection:


### PR DESCRIPTION
As of v0.104.0, the collector listens on `localhost` and not `0.0.0.0`. This breaks containerized environments like cloudrun

https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.104.0