### PR TITLE
fix: add missing `endpoint:` key to grpc & html configuration

### DIFF
--- a/collector/collector-config.yaml
+++ b/collector/collector-config.yaml
@@ -16,9 +16,9 @@ receivers:
   otlp:
     protocols:
       grpc:
-        0.0.0.0:4317
+        endpoint: 0.0.0.0:4317
       http:
-        0.0.0.0:4318
+        endpoint: 0.0.0.0:4318
 
   filelog:
     include: [ /logging/*.log ]

--- a/configs/log-file.yaml
+++ b/configs/log-file.yaml
@@ -19,9 +19,9 @@ receivers:
   otlp:
     protocols:
       grpc:
-        0.0.0.0:4317
+        endpoint: 0.0.0.0:4317
       http:
-        0.0.0.0:4318
+        endpoint: 0.0.0.0:4318
   filelog:
     include: [/logging/*.log]
     start_at: beginning

--- a/configs/push-metrics.yaml
+++ b/configs/push-metrics.yaml
@@ -21,9 +21,9 @@ receivers:
   otlp:
     protocols:
       grpc:
-        0.0.0.0:4317
+        endpoint: 0.0.0.0:4317
       http:
-        0.0.0.0:4318
+        endpoint: 0.0.0.0:4318
 
 processors:
   # automatically detect Cloud Run resource metadata

--- a/configs/rename-metric-attributes.yaml
+++ b/configs/rename-metric-attributes.yaml
@@ -21,9 +21,9 @@ receivers:
   otlp:
     protocols:
       grpc:
-        0.0.0.0:4317
+        endpoint: 0.0.0.0:4317
       http:
-        0.0.0.0:4318
+        endpoint: 0.0.0.0:4318
 
 processors:
   # automatically detect Cloud Run resource metadata

--- a/configs/traces.yaml
+++ b/configs/traces.yaml
@@ -20,9 +20,9 @@ receivers:
   otlp:
     protocols:
       grpc:
-        0.0.0.0:4317
+        endpoint: 0.0.0.0:4317
       http:
-        0.0.0.0:4318
+        endpoint: 0.0.0.0:4318
 
 processors:
   resourcedetection:


### PR DESCRIPTION
Fixes a bug that #24 introduced a bug where `endpoint:` was missing from the YAML configs.