### PR TITLE
Config changes to fix deployment issues

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,6 +33,7 @@ steps:
   - name: "gcr.io/cloud-builders/docker"
     env:
       - "IMAGE_COLLECTOR=${_IMAGE_COLLECTOR}"
+      - "DOCKER_BUILDKIT=1"
     script: |
       docker build -t ${IMAGE_COLLECTOR} ./collector
     id: BUILD_COLLECTOR

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -14,4 +14,4 @@
 
 FROM otel/opentelemetry-collector-contrib:0.87.0
 
-COPY collector-config.yaml /etc/otelcol-contrib/config.yaml
+COPY --chmod=755 collector-config.yaml /etc/otelcol-contrib/config.yaml

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM otel/opentelemetry-collector-contrib:0.87.0
+FROM otel/opentelemetry-collector-contrib:0.121.0
 
 COPY --chmod=755 collector-config.yaml /etc/otelcol-contrib/config.yaml

--- a/collector/collector-config.yaml
+++ b/collector/collector-config.yaml
@@ -58,6 +58,7 @@ exporters:
 
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
 
 service:
   extensions: [health_check]

--- a/run-service.yaml
+++ b/run-service.yaml
@@ -36,6 +36,7 @@ spec:
         - image: "%OTELCOL_IMAGE%"
           name: collector
           startupProbe:
+            initialDelaySeconds: 60
             httpGet:
               path: /
               port: 13133


### PR DESCRIPTION
Some proposed changes to the build and deployment configs to ensure that the demo runs more reliably out-of-the-box.

  1. Bump the collector version to pull in recent changes.
  2. Change permissions on the collector config when copying. Without this, the collector fails to read the config (with permission denied error) and enters a crash loop. Note that this requires DOCKER_BUILDKIT.
  3. Bind to all networks for the healthcheck. The default (localhost) does not work and the startupProbe will fail.
  4. Increase the delay in starting the container health check to give the collector some time to initialize.